### PR TITLE
Additional handling for HTML wrappers

### DIFF
--- a/db2htmlbook.xsl
+++ b/db2htmlbook.xsl
@@ -5,7 +5,7 @@
   xmlns:mml="http://www.w3.org/1998/Math/MathML"
   xsi:schemaLocation="http://www.w3.org/1999/xhtml ../schema/htmlbook.xsd"
   xmlns="http://www.w3.org/1999/xhtml">
-<xsl:output method="xml"/>
+<xsl:output method="xml" omit-xml-declaration="yes"/>
   
 <!-- 
 *******************************


### PR DESCRIPTION
Hi Jess,

Just made a couple small tweaks to add more modular handling of DB->HTMLBook conversion:
- Added an $include-html-wrapper param, which lets you choose whether or not to wrap the HTML content in the standard `<html>/<head>/<body>` tagging. This is on by default, but off so that you can generate bits of an HTML document and then combine as needed.
- Turned off inclusion of the XML declaration at top of document to make the combining mentioned in previous bullet easier to do.

Thanks,
Sanders
