### PR TITLE
Added a process-role template (to preserve @role attributes as class values), and added an include-toc parameter

### DIFF
--- a/db2htmlbook.xsl
+++ b/db2htmlbook.xsl
@@ -1126,19 +1126,9 @@ NAMED TEMPLATES
 </xsl:template>
 
 <xsl:template name="process-role">
-  <xsl:choose>
-    <xsl:when test="@class">
-      <xsl:attribute name="class"><xsl:value-of select="concat(@class, ' ', @role)"/></xsl:attribute>
-    </xsl:when>
-    <xsl:otherwise>
-      <xsl:attribute name="class"><xsl:value-of select="@role"/></xsl:attribute>
-    </xsl:otherwise>
-  </xsl:choose>
-<!--
   <xsl:if test="@role">
     <xsl:attribute name="class"><xsl:value-of select="@role"/></xsl:attribute>
   </xsl:if>
--->
 </xsl:template>
   
 <!-- 


### PR DESCRIPTION
The include-toc parameter is true by default.

Also added process-role to the following elements:
- part
- chapter/preface/appendix/colophon/dedication
- footnote
- para/simpara, formalpara
- sect1, sect2, sect3, sect4, sect5
- sidebar
- note/tip/warning/caution/important
- blockquote/epigraph/quote
- equation/informalequation
- glossary, glossdiv, glossentry, glossterm, glossdef
- itemizedlist, orderedlist, variablelist, simplelist
- procedure, substeps
- programlisting/screen, literallayout, example
- figure/informalfigure
- table/informaltable
- thead, tbody, row, tr, th, td, entry
- indexterm
