### PR TITLE
Adding handling for use with asciidoctor-htmlbook passthrough conversions

### DIFF
--- a/db2htmlbook.xsl
+++ b/db2htmlbook.xsl
@@ -1612,4 +1612,7 @@ UTILITY TEMPLATES
 </xsl:if>
 </xsl:template>
 
+<!--For use with asciidoctor-htmlbook-->
+<xsl:template match="root"/>
+
 </xsl:stylesheet>


### PR DESCRIPTION
- drops dummy `<root>` elements
