### PR TITLE
Adding handling for ids on footnotes in tables

### DIFF
--- a/db2htmlbook.xsl
+++ b/db2htmlbook.xsl
@@ -275,6 +275,7 @@ BLOCKS
 <xsl:template match="footnote[ancestor::table or ancestor::informaltable]|tfoot">
   <sup>
     <xsl:attribute name="class">table-footnote-call</xsl:attribute>
+    <xsl:call-template name="process-id"/>
     <xsl:apply-templates select="." mode="footnote.number"/>
   </sup>
 </xsl:template>


### PR DESCRIPTION
Adding handling for ids on footnotes in tables by adding  `<xsl:call-template name="process-id"/>`  to the appropriate template.