### PR TITLE
Inlineequation mathphrase tags now get data-type="tex" (not "latex")

### DIFF
--- a/db2htmlbook.xsl
+++ b/db2htmlbook.xsl
@@ -442,7 +442,7 @@ BLOCKS
       <!-- To Do: Test inline latex equations -->
       <xsl:when test="mathphrase[@role='tex']">
         <span>
-          <xsl:attribute name="data-type">latex</xsl:attribute>
+          <xsl:attribute name="data-type">tex</xsl:attribute>
           <xsl:copy-of select="mathphrase/text() | mathphrase/*"/>
         </span>
       </xsl:when>


### PR DESCRIPTION
Updating so that inlineequation mathphrase tags propegate to htmlbook with a data-type value of "tex" instead of "latex"