### PR TITLE
TOOLSREQ-6948: Fix secondary sortas attribute

### DIFF
--- a/db2htmlbook.xsl
+++ b/db2htmlbook.xsl
@@ -1039,7 +1039,7 @@ BLOCKS
     <xsl:if test="primary/@sortas">
       <xsl:attribute name="data-primary-sortas"><xsl:value-of select="primary/@sortas"/></xsl:attribute>
     </xsl:if>
-    <xsl:if test="seondary/@sortas">
+    <xsl:if test="secondary/@sortas">
       <xsl:attribute name="data-secondary-sortas"><xsl:value-of select="secondary/@sortas"/></xsl:attribute>
     </xsl:if>
     <xsl:if test="tertiary/@sortas">


### PR DESCRIPTION
This fixes a bug in the script where the `sortas` attribute in `<secondary>` elements was not being copied over when Docbook was converted to HTMLbook. This was caused by a typo where the if clause was looking for "seondary" instead of "secondary", which meant that a correctly marked up element would never satisfy the test. The fix  is to spell "secondary" correctly.

Some context:
* This XSL is used by the Atlas workers when building from Docbook XML source files. It is cloned in the same manner as our other dependency repos like HTMLbook, so deploying the change should work the same as changes to the HTMLBook XSL (https://github.com/oreillymedia/orm-atlas-workers/blob/de7cfe0efdf7a56db3944d1d7d8515a0d018d41b/Dockerfile#L281)
* `<secondary>` is a child element of `<indexterm>` (https://tdg.docbook.org/tdg/4.5/secondary.html)
* `sortas` is used to alphabetize an entry as something else (e.g., "STDIN" instead of "<STDIN>")

The XSPEC tests in this repo seem unfinished and I could not get them running. That may be something we could do in the future, but in my opinion is outside the scope of this ticket. I did test this change by running the script locally and it worked as intended.