### PR TITLE
TOOLSREQ-8310: Changing Sidebar Headers from h5 to h1

### DIFF
--- a/db2htmlbook.xsl
+++ b/db2htmlbook.xsl
@@ -362,7 +362,7 @@ BLOCKS
     <xsl:call-template name="process-id"/>
     <xsl:call-template name="process-role"/>
     <xsl:attribute name="data-type">sidebar</xsl:attribute>
-    <h5><xsl:apply-templates select="title"/></h5>
+    <h1><xsl:apply-templates select="title"/></h1>
     <xsl:apply-templates select="node()[not(self::title)]"/>
   </aside>
 </xsl:template>


### PR DESCRIPTION
This commit changes the heading element for sidebars from h5 to h1. This is being done to improve the appearance of content on the Platform.