### PR TITLE
Add Catalog File

### DIFF
--- a/http_to_https_cat.xml
+++ b/http_to_https_cat.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+
+    <!--This ensures that we perform any requests to oasis-open via https instead of http, which can fail-->
+    <public publicId="-//OASIS//DTD DocBook XML V4.5//EN" uri="https://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd"/>
+
+    <system systemId="http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" uri="https://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd"/>
+
+</catalog>


### PR DESCRIPTION
Per the `saxon` [catalog docs][catalog], if we want to ensure external calls are made via HTTPS, we need to include this file as an argument to tell `saxon` to make this conversion; we don't want to change the source files in this case, since that breaks other things.

We're including it in this repo to align with the other docbook xsl/xml conversion content locations.

[catalog]:https://www.saxonica.com/html/documentation9.9/sourcedocs/xml-catalogs.html